### PR TITLE
header js

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.7/dist/jquery.inputmask.min.js"></script>
    <script src="./js/input-mask.js"></script>
-   <script src="./js/auto-padding.js"></script>
+   <!-- <script src="./js/auto-padding.js"></script> -->
 <script type="module" src="/main.js"></script>
 <script type="module" src="./partials/home/js/modal-hotel.js"></script>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.7/dist/jquery.inputmask.min.js"></script>
    <script src="./js/input-mask.js"></script>
-    
+   <script src="./js/auto-padding.js"></script>
 <script type="module" src="/main.js"></script>
 <script type="module" src="./partials/home/js/modal-hotel.js"></script>
   </body>

--- a/src/js/auto-padding.js
+++ b/src/js/auto-padding.js
@@ -1,0 +1,9 @@
+window.onload = () => {
+
+    if (document.documentElement.clientWidth <1439) {
+        const { height: pageHeaderHeight } = document
+        .querySelector(".header") 
+        .getBoundingClientRect ();
+        document.body.style.paddingTop=`${pageHeaderHeight}px`;
+    }
+}


### PR DESCRIPTION
Доданий js, який ставить padding-top на body розміром з ширину header, працює при ширині екрана менше 1439. Але є особливість: він працює при запуску, перезапуску сторінки. Тобто якщо користувач загрузить її на десктопі або планшеті, то буде все ок, а якщо мінять ширину екрана через developer tools, то потрібно перезагрузити сторінку щоб він запрацював. підключений внизу в index.html. Якщо є можливість при презентації можеш включити той скрипт і розповісти про нього, думаю це буде трохи відрізняти нашу команду від інших. 